### PR TITLE
Move the build phase that sets the git version in the bundle to later do...

### DIFF
--- a/cTiVo.xcodeproj/project.pbxproj
+++ b/cTiVo.xcodeproj/project.pbxproj
@@ -641,6 +641,10 @@
 			children = (
 				D2D60BCD16766FA600CE32DE /* MTDownloadTableView.h */,
 				D2D60BCC16766FA600CE32DE /* MTDownloadTableView.m */,
+				D2901AE71677BB0E001E559C /* MTDownloadTableCellView.h */,
+				D2901AE81677BB0E001E559C /* MTDownloadTableCellView.m */,
+				D2DFA68D1683C27600CD6CE0 /* MTDownloadCheckTableCell.h */,
+				D2DFA68E1683C27600CD6CE0 /* MTDownloadCheckTableCell.m */,
 				D279D3E8167A32FA007F0677 /* MTMainWindowController.h */,
 				D279D3E9167A32FA007F0677 /* MTMainWindowController.m */,
 				D279D3EA167A32FA007F0677 /* MTMainWindowController.xib */,


### PR DESCRIPTION
...wn the line so that we don't fail with an error when the Info.plist doesn't exist yet (e.g. on the first build after a clean build). The idea of this fix is to improve the odds that a potential github collaborator can clone, build and run the project without having to tweak things.
