### PR TITLE
Support multi-word ffmpeg args, multiple streams

### DIFF
--- a/cTiVo/cTiVoScripts/ffmpeg_edl_ac3.sh
+++ b/cTiVo/cTiVoScripts/ffmpeg_edl_ac3.sh
@@ -20,7 +20,6 @@ exit 1
 
 # use dirname $0 to get path to ourselves
 ffmpeg_path=$(dirname "$0")/ffmpeg
-ffmpeg_path=/usr/local/bin/ffmpeg
 
 # kill any encode that's going on in the background before 
 # exiting ourselves

--- a/cTiVo/cTiVoScripts/ffmpeg_edl_ac3.sh
+++ b/cTiVo/cTiVoScripts/ffmpeg_edl_ac3.sh
@@ -88,7 +88,8 @@ launch_and_monitor_ffmpeg() {
       fi
       last_percent="$percent"
     fi
-    sleep 1
+    #hack: "read zero char from keyboard, fail after 1 second", better than "sleep 1" as no process created
+    read -t 1.0 -N 0
   done 
   last_percent="$max_percent"
   echo "$last_percent" | awk '{printf("%.2f %%\n",$1)}'
@@ -170,7 +171,7 @@ declare -a map_opts ac3_opts
 if [[ -n "$video_stream" ]]; then
   map_opts+=(-map "$video_stream")
 else
-  echo "$no_video_stream_message"
+  echo "$no_video_stream_message" >&2
   exit 1
 fi
 if [[ -n "$audio_stream" ]]; then

--- a/cTiVo/cTiVoScripts/ffmpeg_edl_ac3.sh
+++ b/cTiVo/cTiVoScripts/ffmpeg_edl_ac3.sh
@@ -151,7 +151,6 @@ output_base=$(basename "$output")
 input_dir=$(dirname "$input")
 tmpdir="${input_dir}/${output_base%.*}_ffmpeg"
 rm -rf "$tmpdir"
-mkdir -p "$tmpdir/comskip"
 mkdir -p "$tmpdir/logs"
 
 # figure out the duration after cutting, for the progress indicator

--- a/cTiVo/cTiVoScripts/ffmpeg_edl_ac3.sh
+++ b/cTiVo/cTiVoScripts/ffmpeg_edl_ac3.sh
@@ -184,7 +184,7 @@ fi
 if [ -z "$edl_file" ]; then
   # no edl file, don't need to encode segments and merge, simply encode with the modified audio streams
   # TODO: remove -strict -2 once the bundled ffmpeg binary is updated to 3.1.1 or later
-  launch_and_monitor_ffmpeg 0 100 $duration "$output" "$tmpdir/ffmpeg.txt" "${ffmpeg_opts_pre_input[@]}" -i "$input" "${map_opts[@]}" "${ffmpeg_opts_post_input[@]}" -strict -2 -c:a:0 aac "${ac3_opts[@]}"
+  launch_and_monitor_ffmpeg 0 100 $duration "$output" "$tmpdir/logs/ffmpeg.log" "${ffmpeg_opts_pre_input[@]}" -i "$input" "${map_opts[@]}" "${ffmpeg_opts_post_input[@]}" -strict -2 -c:a:0 aac "${ac3_opts[@]}"
 
 else
   # encode segments separately and merge together


### PR DESCRIPTION
Switched to using bash arrays for ffmpeg args, both passed-through and
not.  This will prevent word splitting on args that have spaces, i.e.
long filter strings.  It also makes the generated stream mapping and
audio codec arguments cleaner IMO.

The script is supposed to look at the first video stream and the first audio 
stream in the input file... I don't think this was working before for files 
with more than one audio stream, though I doubt that any TV broadcasters 
currently do this.  This change cleans up the search of video and audio 
streams and ac3 5.1 detection to be more robust.

I also added in fixes for the >& issue and tmpdir name issues referenced
in #183 and #186 though Hugh said he had fixes, I don't see them checked
into dscottbuch 2.5.