### PR TITLE
Fix several missing items in subscription dict

### DIFF
--- a/cTiVo/MTAppDelegate.m
+++ b/cTiVo/MTAppDelegate.m
@@ -236,6 +236,7 @@ __DDLOGHERE__
                                           @240, kMTMaxProgressDelay,
                                           @"tivodecode-ng", kMTDecodeBinary,
                                           @NO, kMTDownloadTSFormat,
+                                          @NO, kMTExportTextMetaData,
                                           @[], kMTChannelInfo,
                                           nil];
     


### PR DESCRIPTION
In trying to figure out how cTiVo remembers which shows were downloaded
for a subscription, I came across MTSubscription.prevRecorded but
realized it was never getting saved.  Turns out this was because
kMTExportTextMetaData was never getting initialized so was always nil
for subscriptions.  Everything after it in the dictionary saved to
kMTSubscriptionList was getting lost, including exportSubtitles,
preferredTivo, HDOnly, SDOnly, and prevRecorded.

Simply initializing kMTExportTextMetaData in the user defaults fixes
this.