### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ cTiVo provides complete hands-off operation: once you choose or subscribe to you
 
 cTiVo was inspired by the great work done on iTiVo, but written in Cocoa/Objective C for better performance and  compatibility. Current or former users of iTiVo will find a detailed comparison and upgrade path described in [iTivo Users](wiki/iTiVoUsers.md).
 
-##Automatic Download and Conversions
+## Automatic Download and Conversions
   * Auto-discovery of all your TiVos (using Bonjour).
   * Drag/drop and contextual menus for ease of use; submit, reschedule, delete all by dragging the shows.
   * Download queue for batch processing, restored on restart.
@@ -21,7 +21,7 @@ cTiVo was inspired by the great work done on iTiVo, but written in Cocoa/Objecti
   * Target devices include iPhone, iPad, AppleTV, Xbox, YouTube.
   * Imports old iTiVo preferences, including subscriptions and Media Access Key.
 
-##Complete Control Over Process
+## Complete Control Over Process
   * Change conversion formats for each download or subscription.
   * Change commercial handling/captioning/metadata/iTunes submittal for each download or subscription.
   * Change download directories for each download.
@@ -34,7 +34,7 @@ cTiVo was inspired by the great work done on iTiVo, but written in Cocoa/Objecti
   * Access remote TiVos (requires network reconfiguration).
   * Folders optionally created for each series.
 
-##Information About Your Shows
+## Information About Your Shows
   * Customizable columns about shows, downloads and subscriptions; show exactly what you want to see and no more.
   * Detailed info available for each show.
   * Contextual menus to play downloaded video, show in Finder, etc.
@@ -52,7 +52,7 @@ cTiVo was inspired by the great work done on iTiVo, but written in Cocoa/Objecti
 * Better handling for AC3 5.1 audio
 * Many bug fixes
 
-##To install:
+## To install:
 
 Download the [cTiVo application](https://github.com/dscottbuch/cTiVo/releases), and drag it to your Applications Folder.
 

--- a/wiki/Advanced-Topics.md
+++ b/wiki/Advanced-Topics.md
@@ -1,5 +1,5 @@
-#Advanced Topics
-##Configuration options designed for advanced users
+# Advanced Topics
+## Configuration options designed for advanced users
 
 This document is to cover some interesting topics, but really for advanced users only  
 
@@ -325,7 +325,7 @@ And you can put these together:
 	==>`The Big Bang Theory/Season 07/The Big Bang Theory - S07E01 - The Hofstadter Insufficiency.mp4`
 	==>`Movies/Machete (2010)`
 
-##A couple of final notes:
+## A couple of final notes:
 * Capitalization is irrelevant in keywords. 
 * Quotes are not allowed inside quotes.
 * Brackets cannot be used as text.

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -1,4 +1,4 @@
-#Configuration
+# Configuration
 ## How to configure cTiVo operation
 
 Although cTiVo should be easy to approach and use, it is also intended to be very configurable, letting the user set things up just the way they want.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -4,17 +4,17 @@
 See [Subscriptions]()
 ### I have questions about my TiVo.  
 Well, cTiVo is designed to get shows from your TiVo to your Mac. If you have questions about your TiVo that TiVo Support can't handle, we highly recommend the [TiVo Community forum](http://TiVocommunity.com/TiVo-vb/index.php).
-###I have shows on my TiVo that are not listed on cTiVo!
+### I have shows on my TiVo that are not listed on cTiVo!
 Certain shows and certain channels can be marked by your cable provider as 'copy-protected'. Your TiVo will not let any show marked as copy-protected be downloaded. Premium Channels (like HBO) are always marked this way. Some regular cable channels also do this. The only ones that are not allowed to be marked copy-protected are the over-the-air networks. cTiVo lets you either show or hide copy-protected programs (Options>Show Protected Shows), but you still can't download the show. If you think too many of your shows are marked, complain to your cable company.
-###cTiVo says "Paused" in big red letters, and nothing is happening.
+### cTiVo says "Paused" in big red letters, and nothing is happening.
 You have the option to pause the queue, either automatically in Preferences or manually with File>Pause Queue (Cmd-U). To resume manually, just hit File>Resume Queue (or Cmd-U).
-###I managed to hide the Show Description drawer.
+### I managed to hide the Show Description drawer.
 To show the show description drawer, double-click on any show.
-###I chose video format XYZ, and Quicktime will not play my video.
+### I chose video format XYZ, and Quicktime will not play my video.
 Some formats are not intended for playing on your computer, and Quicktime is unable to play them. See the [Video Formats](Video-Formats.md) page for more information.
-###I want a different option on the encoding.
+### I want a different option on the encoding.
    See Edit Video Formats in [Advanced Topics](Advanced-Topics.md) 
-###What does the column "Tivo Status" mean?
+### What does the column "Tivo Status" mean?
 These are the icons displayed by TiVo on its NowPlaying status along with a couple we've added for clarity. 
 <table>
     <tr> <td><img src="Images/in-progress-recording.png"></td><td>Recording Now</td></tr>
@@ -30,7 +30,7 @@ These are the icons displayed by TiVo on its NowPlaying status along with a coup
 
 `*` = Ones we've added 
 
-###Is it supposed to be this slow?
+### Is it supposed to be this slow?
  First, yes. Video files are huge, especially HD.
  
 Several things affect the speed of the download:
@@ -42,18 +42,18 @@ Several things affect the speed of the download:
 - Format you are converting to. Higher-resolution, higher-quality formats take more processing power from your computer.
 
 To give you an estimate over a wired connection, from a TiVo HD (aka Series3), converting to iPhone simultaneous encode, you might see a 1.8MBps connection and get a 3.0-gigabyte 30-minute show in about 30  mins. Use those settings as a starting point. If you're seeing MUCH worse times, then something is wrong. You can see the speed of your network connection by running Activity Monitor (Applications>Utilities>Activity Monitor>Network tab). If you have a Roamio, then you might see more like 10MBps, so get a 3.0GB show in 5 minutes
-###What should I do if I need it to download faster?
+### What should I do if I need it to download faster?
    With today's processors and older TiVos, you'll probably be encoding as fast as you can download. If not, if you're ok with using up a lot more hard drive space, you might select the 'Decrypted TiVo Show' format. Then install [MPlayer OSX Extended](http://www.mplayerosx.ch)  or [VLC](http://www.videolan.org/vlc/index.html) to view the downloaded movie. It will download as fast as the TiVo will allow, and do no conversion whatsoever. Otherwise, try out different Formats in cTiVo; many have vastly different performance.
-###What are the different stages that cTiVo goes through?
+### What are the different stages that cTiVo goes through?
    Depending on the options that you've set, cTiVo goes through many different steps to prepare your video.  Note that there are resource constraints that will prevent the program from attempting all in parallel. For example, we only download one show at a time from each TiVo as trying to do more will be counterproductive. Thus a show might pause mid-way through processing until further resources are available.
   Download => Decrypt => Ads Detect => Subtitle Extraction => Video Encoding => Adding Metadata => Adding to iTunes ==> Complete 
    We optimize to do as many of these as possible in parallel, so several of these steps may be combined into one; for example, the download might say "Downloading" until the download is complete, then say "Encoding", even though much of the file may already be decrypted/encoded. Shows can also be marked as "Failed" or "TiVo Deleted", meaning that the show is no longer available on the TiVo. A blank entry means that it's not been started yet (or has failed and is scheduled for automatic retry).
-###My shows aren't downloading; although I can see the list and can request a download, every show tries several times, then gives up.
+### My shows aren't downloading; although I can see the list and can request a download, every show tries several times, then gives up.
 This symptom may mean that your TiVo's internal file server has crashed. It's quite delicate, and certain combinations of operations (which we try to avoid) can cause problems. Try restarting your TiVo (TiVo Central > Messages & Settings > Restart or Reset System > Restart the TiVo; doing this while recording will cancel recording) and see if the problem is fixed. If it does and yet reoccurs later, let us know.
-###My program crashes / I get mencoder or tivodecode errors, etc.
+### My program crashes / I get mencoder or tivodecode errors, etc.
  The short version: sorry; let us know, and we'll try to fix it.
 The long version: cTiVo is actually a front-end for several programs written by multiple people. See the About cTiVo menu item for more details. Many of these programs are not perfect, and cTiVo may have its own bugs. If you report bugs in the *Issues* tab above, we will get around to checking it out. However, the bug may be related to underlying programs which we have no control over.  One thing to always try is a different download format, or a different encoder (for example, HandBrake iPhone instead of iPhone). Comskip in particular, is very prone to crashing or failing. When this happens, we put up an error message, but we continue with the processing, simply not marking/skipping commercials.
-###This program has bugs!
+### This program has bugs!
    We appreciate bug reports, and will do our best to fix them. But please keep in mind that we're working on this in our spare time, and we are not charging you anything...
 
 Note: as cTiVo is based on the original iTivo project, we have reused and updated many of these questions from there.

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,4 +1,4 @@
-#Installation
+# Installation
 ## How to install cTiVo
 
 1. cTiVo requires MacOS X 10.7 (Lion) or newer.

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -1,4 +1,4 @@
-#Overview
+# Overview
 ## An overview of cTiVo operation and controls
 
 In this document, we describe the following parts of cTiVo operation:

--- a/wiki/Quick-Start.md
+++ b/wiki/Quick-Start.md
@@ -1,4 +1,4 @@
-#Quick Start
+# Quick Start
 ## How to get cTiVo running quickly
 
 Note: this page assumes you are familiar with TiVo and how to set up software. If you need more detailed instructions, please see [Installation](installation.md), or the references below. Or see the special instructions for [iTiVo users](iTiVo-Users).

--- a/wiki/Subscriptions.md
+++ b/wiki/Subscriptions.md
@@ -1,4 +1,4 @@
-#Subscriptions
+# Subscriptions
 ## How to set up and configure subscriptions in cTiVo
 
 One of the main features of cTiVo is the ability to subscribe to a series. Subscribing means that all episode of that series will be automatically downloaded for your convenience, even copied onto your phone for later viewing.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,5 +1,5 @@
-#Advanced Topics
-##Configuration options designed for advanced users
+# Advanced Topics
+## Configuration options designed for advanced users
 
 This document is to cover some interesting topics that are intended for advanced users only.
 

--- a/wiki/Video-Formats.md
+++ b/wiki/Video-Formats.md
@@ -1,9 +1,9 @@
-##Video Formats
+## Video Formats
 Video can be stored in many different ways in a file. Many factors such as resolution (the number of horizontal and vertical pixels), the encoder used, the amount of compression, all affect both the amount of space used and the quality of the resulting video. The video formats used by broadcasters are not very compatible with those used by computer industry so cTiVo needs to convert the vido files that you bring over from your TiVo. 
 
 In order to maximize flexibilty while keeping it simple, cTiVo gives you a choices of "Formats". A Format stores the information needed to convert to a specific video format. We provide a wide range, in addition, you can use the Format Editor to build your own. 
 
-##Selecting a Format for cTiVo
+## Selecting a Format for cTiVo
 As the name suggests, the "Default" Format should work well for most uses, but we've provided many alternatives to handle different situations. 
 
 Generally speaking, there are tradeoffs between:
@@ -48,7 +48,7 @@ Certain other formats are built-in, but hidden to keep thing simple. To enable, 
 
 Finally, we also have a full set of Formats using two other encoders: Handbrake and Elgato's Turbo.264HD. While Elgato is relatively uncommon, Handbrake is also highly recommended, and has a large number of predefined settings. To keep things simple, these are hidden in the default settings, but if the ffmpeg-based ones don't work for you, feel free to give Handbrake a try. Note that Handbrake does not support Commercial skipping (actually cutting the commercials out the videO), only marking (which makes it easy to skip commercials during playback).
 
-##Relative Performance
+## Relative Performance
 To give you an indication of relative performance of these encoders, we ran 8 different files with each Format. As the performance varies widely, particularly depending on output resolution, the results are separated for 1080i source shows as well as shows smaller than that.
 
 |  Name           | AC3 | Max Res | Small Size |Small Time| 1080i Size | 1080i Time|
@@ -75,7 +75,7 @@ AC3 = Includes Surround sound in output file (vs just stereo), which will add 5-
 Size and Time ratios are versus the original TiVo file, so 50% and .7x for a 1GB, 1hr show would mean that the resulting file was 500MB and took 42 minutes to convert.
 Time values given are run on a 2014 MacBook Pro; 2.5 GHz Intel Core i7. Only one conversion occuring at a time, with no other work going on in the same machine. Does not include download time. Your mileage may vary.
 
-##Building your Own Format
+## Building your Own Format
 If none of these work for you, and you're somewhat technical, feel free to create your own Format. The [detailed instructions are here](Advanced-Topics#edit-formats), but the general idea is to (a) select an existing one that's close to what you want, (b) Duplicate it in the Format Editor, and (c) modify however you choose. If it doesn't do what you expect, look in the logs to see messages from the encoders. Due to the wide range of Handbrake presets, there's an easy mechanism to create a new Handbrake Format: just select an existing Handbrake Format in the Editor, and select a new Preset including user-defined ones.
 
 If you'd like more information on these topics, here's a couple of good resources:

--- a/wiki/iTiVo-Users.md
+++ b/wiki/iTiVo-Users.md
@@ -1,4 +1,4 @@
-#iTiVo Users
+# iTiVo Users
 ## Quick overview of cTiVo for iTiVo users
 
 cTiVo is inspired by the great work done on iTiVo, but completely rewritten in Cocoa/Objective-C for better performance and compatability. 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
